### PR TITLE
Fix import for IntelliJ IDEA

### DIFF
--- a/Test.scala
+++ b/Test.scala
@@ -1,4 +1,4 @@
-import offheap._
+import scala.offheap._
 
 @data class Point(x: Int, y: Int)
 


### PR DESCRIPTION
IntelliJ Scala plugin can't resolve offheap._ as scala.offheap._ so it might be a good idea to fix import in the example to avoid user confusion.
